### PR TITLE
Avoid browser + server caching when fetching create.php

### DIFF
--- a/archive/install.php
+++ b/archive/install.php
@@ -184,7 +184,7 @@ echo '<!DOCTYPE html>
 			$(function() {
 				var updateContent = function(type) {
 					var company = $("#company").val();
-                                        var nocache = new Date().getTime();
+					var nocache = new Date().getTime();
 					$(".uk-grid").load("create.php?s=" + type + "&p=" + company +
 								    \'&no_cache=\' + nocache);
 

--- a/install.php
+++ b/install.php
@@ -184,7 +184,7 @@ echo '<!DOCTYPE html>
 			$(function() {
 				var updateContent = function(type) {
 					var company = $("#company").val();
-                                        var nocache = new Date().getTime();
+					var nocache = new Date().getTime();
 					$(".uk-grid").load("create.php?s=" + type + "&p=" + company +
 								    \'&no_cache=\' + nocache);
 


### PR DESCRIPTION
Adding a ghost query to our create.php fetch URL to make sure we avoid browser and server caching; this is a problem on hosts such as GoDaddy as it will never update the page.

I've also updated install.php to use the same javascript (that actually works) in archive/install.php.
