### PR TITLE
Bugfix: Additional links on project page were breaking.

### DIFF
--- a/archive/sheet.php
+++ b/archive/sheet.php
@@ -750,8 +750,13 @@ for( $i = 0; $i < count($additionals); $i++ )
 	}
 
 	if( strpos(parseLink($link),'/') !== 0 ) {
-		$linkTitle = substr(parseLink($link),0,strpos(parseLink($link),'/'));
-	} else { $linkTitle = $link; }
+		if(strpos(parseLink($link),'/') === false) {
+			$linkTitle = parseLink($link);
+		} else {
+			$linkTitle = substr(parseLink($link),0,strpos(parseLink($link),'/'));
+		}
+	}
+	else { $linkTitle = $link; }
 	
 	echo '<p>
 	<strong>'.$title.'</strong><br/>


### PR DESCRIPTION
If and additional link on a project page did not contain a slash after the domain name then it would be assigned an empty link title and the link would therefore be invisible. 

www.domainname.com  pattern results in the bug as seen here:
http://grab.by/uKew

Where  as www.domainname.com/no-bug pattern seems to work fine. 

As a fix I've implemented a simple check to bypass domains with no post-fix url information to be ignored from the stripping routine.
