### PR TITLE
Fixes for broken HTML.

### DIFF
--- a/archive/sheet.php
+++ b/archive/sheet.php
@@ -302,7 +302,7 @@ echo '<!DOCTYPE html>
 			<div class="uk-grid">
 				<div id="navigation" class="uk-width-medium-1-4">
 					<h1 class="nav-header">'. COMPANY_TITLE .'</h1>
-					<a class="nav-header" href="index.php" target="_self">press kit</a></strong>
+					<a class="nav-header" href="index.php" target="_self">press kit</a>
 
 					<ul class="uk-nav uk-nav-side">
 						<li><a href="#factsheet">Factsheet</a></li>

--- a/archive/sheet.php
+++ b/archive/sheet.php
@@ -363,7 +363,7 @@ echo '							</p>
 								<strong>Website:</strong><br/>
 								<a href="http://'. parseLink(GAME_WEBSITE) .'">'. parseLink(GAME_WEBSITE) .'</a>
 							</p>
-							<p>
+							<div>
 								<strong>Regular Price:</strong><br/>';
 
 if( count($prices) == 0 )
@@ -390,7 +390,7 @@ else
 	echo'</table>';
 }
 
-echo'							</p>
+echo'							</div>
 						</div>
 						<div class="uk-width-medium-4-6">
 							<h2 id="description">Description</h2>

--- a/archive/sheet.php
+++ b/archive/sheet.php
@@ -210,7 +210,7 @@ foreach( $xml->children() as $child )
 			$promotercode = ($child->children());
 			$promotercode = $promotercode->product;
 			
-			$promoterxml = simplexml_load_file('http://promoterapp.com/dopresskit/'.$promotercode);
+			$promoterxml = simplexml_load_file('http://www.promoterapp.com/dopresskit/'.$promotercode);
 			
 			foreach( $promoterxml->children() as $promoterchild )
 			{

--- a/archive/sheet.php
+++ b/archive/sheet.php
@@ -755,7 +755,7 @@ for( $i = 0; $i < count($additionals); $i++ )
 	
 	echo '<p>
 	<strong>'.$title.'</strong><br/>
-	'.$description.' <a href="http://'.parseLink($link).'" alt="'.parseLink($link).'">'.$linkTitle.'</a>.
+	'.$description.' <a href="http://'.parseLink($link).'">'.$linkTitle.'</a>.
 </p>';
 }
 


### PR DESCRIPTION
Fixed W3C validation errors (broken HTML):
- Removed a closing strong tag which did not have a corresponding
  opening tag.
- Removed invalid alt property from a tag.
- Replaced p with div since it contains a table tag.
