### PR TITLE
Fix for award header remaining on primary index when there are no award ...

### DIFF
--- a/archive/index.php
+++ b/archive/index.php
@@ -469,7 +469,7 @@ if( !file_exists('images/logo.png') && !file_exists('images/icon.png')) {
 
 echo '					<hr>';
 
-if( count( $awards > 0 ) )
+if( count( $awards ) > 0 )
 {
 	echo('<h2 id="awards">Awards & Recognition</h2>
 					<ul>');


### PR DESCRIPTION
Simple change to an incorrectly nested compare.
