### PR TITLE
Don't show awards title if there are no awards

### DIFF
--- a/archive/index.php
+++ b/archive/index.php
@@ -501,7 +501,7 @@ if( !file_exists('images/logo.png') && !file_exists('images/icon.png')) {
 
 echo '					<hr>';
 
-if( count( $awards > 0 ) )
+if( count( $awards ) > 0 )
 {
 	echo('<h2 id="awards">'. tl('Awards & Recognition') .'</h2>
 					<ul>');


### PR DESCRIPTION
The previous check was invalid as the > 0 was inside the call to count()