### PR TITLE
Fix additional links being shown with an empty

### DIFF
--- a/archive/sheet.php
+++ b/archive/sheet.php
@@ -850,7 +850,7 @@ for( $i = 0; $i < count($additionals); $i++ )
 		}
 	}
 
-	if( strpos(parseLink($link),'/') !== 0 ) {
+	if( strpos(parseLink($link),'/') !== false ) {
 		$linkTitle = substr(parseLink($link),0,strpos(parseLink($link),'/'));
 	} else { $linkTitle = $link; }
 	


### PR DESCRIPTION
In project pages, additional links that don't contain a subpath (e.g. `domain.com` instead of `domain.com/path`) are shown with an empty title, i.e. not appearing at all in the rendered page.

The behavior of the code for additional links is also not in sync between the index page and project pages. The index pages compares the `strpos` result to `!== false` (does not contain) whereas the project page compares it to `!== 0` (does not begin with), which causes the issue.

This pull requests fixes the issue and brings the behavior on the main page and project pages in line, always checking if the link contains a `/`.

I'm not sure if the behavior of this title-parsing is very useful anyway. I think it would be clearer to always show the link as it was entered and provide an optional title field in the xml to set the title manually.